### PR TITLE
Fix navigation home link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -24,10 +24,10 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
-            <a class="navbar-brand fw-bold" href="{% url 'index' %}">
+            <a class="navbar-brand fw-bold" href="{% url 'home' %}">
                 <i class="fas fa-shield-alt me-2"></i>Safe Campus
             </a>
-            
+
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -35,7 +35,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link {% if request.resolver_match.url_name == 'index' %}active{% endif %}" href="{% url 'index' %}">Home</a>
+                        <a class="nav-link {% if request.resolver_match.url_name == 'home' %}active{% endif %}" href="{% url 'home' %}">Home</a>
                     </li>
                     <li class="nav-item">
 


### PR DESCRIPTION
## Summary
- Update navigation links to use the existing `home` route instead of a non-existent `index` route

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b971d71520832f9b333f40d4994c57